### PR TITLE
Add fedora installation instuctions for wayland-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install wayland-automation
 | Dependency | What it does | Install command |
 |---|---|---|
 | `wtype` | **Required** — keyboard automation | `sudo pacman -S wtype` (Arch) / `sudo apt install wtype` (Debian) / `sudo dnf install wtype` (Fedora) |
-| `wayland-utils` | Screen resolution detection | `sudo pacman -S wayland-utils` (Arch) / `sudo apt install wayland-utils` (Debian) |
+| `wayland-utils` | Screen resolution detection | `sudo pacman -S wayland-utils` (Arch) / `sudo apt install wayland-utils` (Debian) / `sudo dnf install wayland-utils` (Fedora) |
 
 #### Mouse-tracking backends (pick the one for your compositor)
 


### PR DESCRIPTION
Added the explicit command for installing the wayland-utils dependency on Fedora to the README, it seemed to be missing. 

This is the official package, the [wayland-utils](https://packages.fedoraproject.org/pkgs/wayland-utils/wayland-utils/) fedora package is linked to the official https://wayland.freedesktop.org/ git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Fedora installation instructions for `wayland-utils` to the installation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->