### PR TITLE
fix: double import when package is executed with '-m' flag

### DIFF
--- a/wayland_automation/__init__.py
+++ b/wayland_automation/__init__.py
@@ -11,9 +11,11 @@ Quick start::
     wa.hotkey("ctrl", "s")              # keyboard shortcut
 """
 
-from .mouse_controller import Mouse, print_usage
-from .mouse_position import mouse_position_generator
-from .keyboard_controller import Keyboard
+import sys
+if not '-m' in sys.argv:
+    from .keyboard_controller import Keyboard
+    from .mouse_position import mouse_position_generator
+    from .mouse_controller import Mouse,print_usage
 
 __version__ = "0.2.8"
 


### PR DESCRIPTION
When we run programs with '-m' flag python by default imports all modules in path, if we have import statements in path a double import occurs and we see a run time warning. 

```py
test@machine ~/P/Wayland-automation (main)> python -m wayland_automation.mouse_controller swipe 10 999 800 200
<frozen runpy>:130: RuntimeWarning: 'wayland_automation.mouse_controller' found in sys.modules after import of package 'wayland_automation', but prior to execution of 'wayland_automation.mouse_controller'; this may result in unpredictable behaviour
INFO: Connected to Wayland server at /run/user/1000/wayland-1
INFO: Bound to zwlr_virtual_pointer_manager_v1
```

Fixes just that by simply not importing when ran with '-m' flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line startup behavior by skipping optional module imports when running with the `-m` option.
  * Preserved standard imports and usage information in other execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->